### PR TITLE
fix: accept/decline writes to selected_list

### DIFF
--- a/app/src/main/java/com/example/spiral_event_lottery_app/acceptanceHandling.java
+++ b/app/src/main/java/com/example/spiral_event_lottery_app/acceptanceHandling.java
@@ -32,9 +32,8 @@ public class acceptanceHandling {
             return; // Don't hit firebase with garbage data
         }
         
-        // Try entrants collection first (lottery result location)
         DocumentReference doc_path = db_identify.collection("events").document(event_id)
-                .collection("entrants").document(device_id);
+                .collection("selected_list").document(device_id);
         
         Map<String, Object> data = new HashMap<>();
         data.put("Status", "Accepted");
@@ -65,7 +64,7 @@ public class acceptanceHandling {
         }
         
         DocumentReference doc_path = db_identify.collection("events").document(event_id)
-                .collection("entrants").document(device_id);
+                .collection("selected_list").document(device_id);
         
         Map<String, Object> data = new HashMap<>();
         data.put("Status", "Declined");


### PR DESCRIPTION
Fixed acceptanceHandling.java to write to the correct Firestore collection when an entrant accepts or declines an event invitation.
Problem
The invitation_accepted() and invitation_declined() methods were writing to events/{eventId}/entrants/{deviceId} which is never read by any other part of the app. This meant the accept/decline action silently succeeded but had no effect on the entrant's actual status.
Fix
Changed both methods to write to events/{eventId}/selected_list/{deviceId} which is the collection the rest of the app (EventRepository) uses to check if a user has been selected.
Testing
Manually tested on a physical Android device by inserting an ACCEPTED notification in Firestore and confirming that tapping Accept correctly creates a document with Status: Accepted in the selected_list subcollection.
User Stories Covered

US 01.05.02 - Accept invitation to register for a chosen event
US 01.05.03 - Decline invitation when chosen to participate